### PR TITLE
sharing a VariableExpression instance which refers to "this" is unsafe

### DIFF
--- a/build-test-data/src/java/grails/buildtestdata/mixin/BuildTransformation.java
+++ b/build-test-data/src/java/grails/buildtestdata/mixin/BuildTransformation.java
@@ -128,6 +128,6 @@ public class BuildTransformation extends TestForTransformation {
         for (ClassExpression targetClass : targetClasses) {
             args.addExpression(targetClass);
         }
-        methodBody.getStatements().add(0, new ExpressionStatement(new MethodCallExpression(THIS_EXPRESSION, "mockForBuild", args)));
+        methodBody.getStatements().add(0, new ExpressionStatement(new MethodCallExpression(new VariableExpression("this"), "mockForBuild", args)));
     }
 }


### PR DESCRIPTION
- TestMixinTransformation.THIS_EXPRESSION was removed from Grails
- see https://github.com/grails/grails-core/commit/685a94c78e39c32f5c44d6681a67e0997cb16e54
