### PR TITLE
Now able to specify name of TestDataConfiguration file in Config.groovy

### DIFF
--- a/alternativeConfig/application.properties
+++ b/alternativeConfig/application.properties
@@ -1,0 +1,5 @@
+#Grails Metadata file
+#Wed Mar 05 14:29:23 CET 2014
+app.grails.version=2.3.5
+app.name=alternativeConfig
+app.version=0.1

--- a/alternativeConfig/grails-app/conf/AlternativeTestDataConfig.groovy
+++ b/alternativeConfig/grails-app/conf/AlternativeTestDataConfig.groovy
@@ -1,0 +1,19 @@
+testDataConfig {
+    sampleData {
+        // Simple class is in "alternativeconfig" package so we use a string in the builder
+        'alternativeconfig.Simple' {
+            name = "Alternative name"
+        }
+    }
+}
+
+// if you'd like to disable the build-test-data plugin in an environment, just set
+// the "enabled" property to false
+
+environments {
+    production {
+        testDataConfig {
+            enabled = false
+        }
+    }
+}

--- a/alternativeConfig/grails-app/conf/BootStrap.groovy
+++ b/alternativeConfig/grails-app/conf/BootStrap.groovy
@@ -1,0 +1,7 @@
+class BootStrap {
+
+    def init = { servletContext ->
+    }
+    def destroy = {
+    }
+}

--- a/alternativeConfig/grails-app/conf/BuildConfig.groovy
+++ b/alternativeConfig/grails-app/conf/BuildConfig.groovy
@@ -1,0 +1,39 @@
+grails.plugin.location.buildTestData = "../build-test-data"
+
+grails.servlet.version = "3.0" // Change depending on target container compliance (2.5 or 3.0)
+grails.project.class.dir = "target/classes"
+grails.project.test.class.dir = "target/test-classes"
+grails.project.test.reports.dir = "target/test-reports"
+grails.project.work.dir = "target/work"
+grails.project.target.level = 1.6
+grails.project.source.level = 1.6
+
+grails.project.fork = [
+    test: false //[maxMemory: 768, minMemory: 64, debug: false, maxPerm: 256, daemon:true],
+]
+
+grails.project.dependency.resolver = "maven" // or ivy
+grails.project.dependency.resolution = {
+    inherits("global") {
+    }
+    log "error"
+    checksums true
+    legacyResolve false
+
+    repositories {
+        inherits true
+
+        grailsPlugins()
+        grailsHome()
+        mavenLocal()
+        grailsCentral()
+        mavenCentral()
+    }
+
+    dependencies {
+    }
+
+    plugins {
+        runtime ":hibernate:3.6.10.7" // or ":hibernate4:4.1.11.6"
+    }
+}

--- a/alternativeConfig/grails-app/conf/Config.groovy
+++ b/alternativeConfig/grails-app/conf/Config.groovy
@@ -1,0 +1,117 @@
+// locations to search for config files that get merged into the main config;
+// config files can be ConfigSlurper scripts, Java properties files, or classes
+// in the classpath in ConfigSlurper format
+
+// grails.config.locations = [ "classpath:${appName}-config.properties",
+//                             "classpath:${appName}-config.groovy",
+//                             "file:${userHome}/.grails/${appName}-config.properties",
+//                             "file:${userHome}/.grails/${appName}-config.groovy"]
+
+// if (System.properties["${appName}.config.location"]) {
+//    grails.config.locations << "file:" + System.properties["${appName}.config.location"]
+// }
+
+grails.project.groupId = appName // change this to alter the default package name and Maven publishing destination
+
+// The ACCEPT header will not be used for content negotiation for user agents containing the following strings (defaults to the 4 major rendering engines)
+grails.mime.disable.accept.header.userAgents = ['Gecko', 'WebKit', 'Presto', 'Trident']
+grails.mime.types = [ // the first one is the default format
+    all:           '*/*', // 'all' maps to '*' or the first available format in withFormat
+    atom:          'application/atom+xml',
+    css:           'text/css',
+    csv:           'text/csv',
+    form:          'application/x-www-form-urlencoded',
+    html:          ['text/html','application/xhtml+xml'],
+    js:            'text/javascript',
+    json:          ['application/json', 'text/json'],
+    multipartForm: 'multipart/form-data',
+    rss:           'application/rss+xml',
+    text:          'text/plain',
+    hal:           ['application/hal+json','application/hal+xml'],
+    xml:           ['text/xml', 'application/xml']
+]
+
+// URL Mapping Cache Max Size, defaults to 5000
+//grails.urlmapping.cache.maxsize = 1000
+
+// What URL patterns should be processed by the resources plugin
+grails.resources.adhoc.patterns = ['/images/*', '/css/*', '/js/*', '/plugins/*']
+
+// Legacy setting for codec used to encode data with ${}
+grails.views.default.codec = "html"
+
+// The default scope for controllers. May be prototype, session or singleton.
+// If unspecified, controllers are prototype scoped.
+grails.controllers.defaultScope = 'singleton'
+
+// GSP settings
+grails {
+    views {
+        gsp {
+            encoding = 'UTF-8'
+            htmlcodec = 'xml' // use xml escaping instead of HTML4 escaping
+            codecs {
+                expression = 'html' // escapes values inside ${}
+                scriptlet = 'html' // escapes output from scriptlets in GSPs
+                taglib = 'none' // escapes output from taglibs
+                staticparts = 'none' // escapes output from static template parts
+            }
+        }
+        // escapes all not-encoded output at final stage of outputting
+        filteringCodecForContentType {
+            //'text/html' = 'html'
+        }
+    }
+}
+ 
+grails.converters.encoding = "UTF-8"
+// scaffolding templates configuration
+grails.scaffolding.templates.domainSuffix = 'Instance'
+
+// Set to false to use the new Grails 1.2 JSONBuilder in the render method
+grails.json.legacy.builder = false
+// enabled native2ascii conversion of i18n properties files
+grails.enable.native2ascii = true
+// packages to include in Spring bean scanning
+grails.spring.bean.packages = []
+// whether to disable processing of multi part requests
+grails.web.disable.multipart=false
+
+// request parameters to mask when logging exceptions
+grails.exceptionresolver.params.exclude = ['password']
+
+// configure auto-caching of queries by default (if false you can cache individual queries with 'cache: true')
+grails.hibernate.cache.queries = false
+
+environments {
+    development {
+        grails.logging.jul.usebridge = true
+    }
+    production {
+        grails.logging.jul.usebridge = false
+        // TODO: grails.serverURL = "http://www.changeme.com"
+    }
+}
+
+// log4j configuration
+log4j = {
+    // Example of changing the log pattern for the default console appender:
+    //
+    //appenders {
+    //    console name:'stdout', layout:pattern(conversionPattern: '%c{2} %m%n')
+    //}
+
+    error  'org.codehaus.groovy.grails.web.servlet',        // controllers
+           'org.codehaus.groovy.grails.web.pages',          // GSP
+           'org.codehaus.groovy.grails.web.sitemesh',       // layouts
+           'org.codehaus.groovy.grails.web.mapping.filter', // URL mapping
+           'org.codehaus.groovy.grails.web.mapping',        // URL mapping
+           'org.codehaus.groovy.grails.commons',            // core / classloading
+           'org.codehaus.groovy.grails.plugins',            // plugins
+           'org.codehaus.groovy.grails.orm.hibernate',      // hibernate integration
+           'org.springframework',
+           'org.hibernate',
+           'net.sf.ehcache.hibernate'
+}
+
+grails.buildtestdata.testDataConfig = "AlternativeTestDataConfig"

--- a/alternativeConfig/grails-app/conf/DataSource.groovy
+++ b/alternativeConfig/grails-app/conf/DataSource.groovy
@@ -1,0 +1,45 @@
+dataSource {
+    pooled = true
+    driverClassName = "org.h2.Driver"
+    username = "sa"
+    password = ""
+}
+hibernate {
+    cache.use_second_level_cache = true
+    cache.use_query_cache = false
+    cache.region.factory_class = 'net.sf.ehcache.hibernate.EhCacheRegionFactory' // Hibernate 3
+//    cache.region.factory_class = 'org.hibernate.cache.ehcache.EhCacheRegionFactory' // Hibernate 4
+}
+
+// environment specific settings
+environments {
+    development {
+        dataSource {
+            dbCreate = "create-drop" // one of 'create', 'create-drop', 'update', 'validate', ''
+            url = "jdbc:h2:mem:devDb;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE"
+        }
+    }
+    test {
+        dataSource {
+            dbCreate = "update"
+            url = "jdbc:h2:mem:testDb;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE"
+        }
+    }
+    production {
+        dataSource {
+            dbCreate = "update"
+            url = "jdbc:h2:prodDb;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE"
+            properties {
+               maxActive = -1
+               minEvictableIdleTimeMillis=1800000
+               timeBetweenEvictionRunsMillis=1800000
+               numTestsPerEvictionRun=3
+               testOnBorrow=true
+               testWhileIdle=true
+               testOnReturn=false
+               validationQuery="SELECT 1"
+               jdbcInterceptors="ConnectionState"
+            }
+        }
+    }
+}

--- a/alternativeConfig/grails-app/conf/spring/resources.groovy
+++ b/alternativeConfig/grails-app/conf/spring/resources.groovy
@@ -1,0 +1,3 @@
+// Place your Spring DSL code here
+beans = {
+}

--- a/alternativeConfig/grails-app/domain/alternativeconfig/Simple.groovy
+++ b/alternativeConfig/grails-app/domain/alternativeconfig/Simple.groovy
@@ -1,0 +1,8 @@
+package alternativeconfig
+
+class Simple {
+    String name
+    static constraints = {
+        name nullable: false
+    }
+}

--- a/alternativeConfig/test/unit/alternativeconfig/SimpleSpec.groovy
+++ b/alternativeConfig/test/unit/alternativeconfig/SimpleSpec.groovy
@@ -1,0 +1,20 @@
+package alternativeconfig
+import grails.buildtestdata.mixin.Build
+import grails.test.mixin.TestFor
+import grails.util.Holders
+import spock.lang.Specification
+/**
+ * See the API for {@link grails.test.mixin.domain.DomainClassUnitTestMixin} for usage instructions
+ */
+@TestFor(Simple)
+@Build(Simple)
+class SimpleSpec extends Specification {
+
+    void "test that build is done with the alternative config file"() {
+        expect:
+        Holders.config.grails.buildtestdata.testDataConfig == "AlternativeTestDataConfig"
+
+        and:
+        Simple.build().name == "Alternative name"
+    }
+}

--- a/build-test-data/BuildTestDataGrailsPlugin.groovy
+++ b/build-test-data/BuildTestDataGrailsPlugin.groovy
@@ -5,7 +5,7 @@ import groovy.util.logging.Commons
 
 @Commons
 class BuildTestDataGrailsPlugin {
-    def version = "2.1.1"
+    def version = "2.1.1-SNAPSHOT"
     def grailsVersion = "2.0.0 > *"
     def loadAfter = ['services', 'dataSource', 'hibernate', 'hibernate4', 'validation']
     def watchedResources = ["file:./grails-app/domain/**.groovy"]
@@ -22,7 +22,8 @@ their constraints examined and a value is automatically provided for them.
             [ name: "Ted Naleid", email: "contact@naleid.com" ],
             [ name: "Joe Hoover" ],
             [ name: "Matt Sheehan" ],
-            [ name: "Aaron Long" ]
+            [ name: "Aaron Long" ],
+            [ name: "Søren Berg Glasius", email: "soeren@glasius.dk"]
     ]
 
     def documentation = "https://github.com/tednaleid/build-test-data/wiki"

--- a/build-test-data/src/groovy/grails/buildtestdata/TestDataConfigurationHolder.groovy
+++ b/build-test-data/src/groovy/grails/buildtestdata/TestDataConfigurationHolder.groovy
@@ -1,7 +1,7 @@
 package grails.buildtestdata
 
 import grails.util.Environment
-
+import grails.util.Holders
 import org.apache.commons.logging.LogFactory
 
 class TestDataConfigurationHolder {
@@ -52,10 +52,11 @@ class TestDataConfigurationHolder {
 
     static Class getDefaultTestDataConfigClass() {
         GroovyClassLoader classLoader = new GroovyClassLoader(TestDataConfigurationHolder.classLoader)
+        String testDataConfig = Holders.config?.grails?.buildtestdata?.testDataConfig ?: 'TestDataConfig'
         try {
-            return classLoader.loadClass('TestDataConfig')
+            return classLoader.loadClass(testDataConfig)
         } catch (ClassNotFoundException ignored) {
-            log.warn "TestDataConfig.groovy not found, build-test-data plugin proceeding without config file"
+            log.warn "${testDataConfig}.groovy not found, build-test-data plugin proceeding without config file"
             return null
         }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include 'bookStore', 'baseTests', 'build-test-data', 'testOptionalJars'
+include 'bookStore', 'baseTests', 'build-test-data', 'testOptionalJars', 'alternativeConfig'


### PR DESCRIPTION
When having a project with multiple inlined plugins one gets an "Invalid duplicate class definition of class TestDataConfig", if the TestDataConfig.groovy file is present in multiple plugins depending on each other.
To solve this, I have changed the TestDataConfigurationHolder to read a setting in Config.groovy, and if grails.buildtestdata.testDataConfig is set, it will try to read this file instead of TestDataConfig.groovy.

Included is a small test project.
