### PR TITLE
Override install stage in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,3 @@
 language: groovy
 script: ./bin/test-all-grailsw
+install: /bin/true


### PR DESCRIPTION
The install stage is what runs `gradle assemble`, this empties the install phase, focusing only on the `script` phase in the build.
