### PR TITLE
Handle circular references with class hierarchy

### DIFF
--- a/baseTests/test/integration/DomainTestDataServiceRelationTests.groovy
+++ b/baseTests/test/integration/DomainTestDataServiceRelationTests.groovy
@@ -81,6 +81,32 @@ class DomainTestDataServiceRelationTests extends DomainTestDataServiceBase {
     }
 
     @Test
+    void testCascadingBuildCircularTwoClassesWithChildClass() {
+        def domainArtefact = registerDomainClass(CircularOne)
+        buildTestDataService.decorateWithMethods(domainArtefact)
+        domainArtefact = registerDomainClass(CircularOneChild)
+        buildTestDataService.decorateWithMethods(domainArtefact)
+        domainArtefact = registerDomainClass(CircularTwo)
+        buildTestDataService.decorateWithMethods(domainArtefact)
+
+        def circDomainOne = new DefaultGrailsDomainClass(CircularOne)
+        def domainProp = circDomainOne.properties.find {it.name == 'circularTwo' }
+        assert domainProp.isOneToOne()
+
+        def circDomainOneChild = new DefaultGrailsDomainClass(CircularOneChild)
+        domainProp = circDomainOneChild.properties.find {it.name == 'circularTwo' }
+        assert domainProp.isOneToOne()
+
+        def circDomainTwo = new DefaultGrailsDomainClass(CircularTwo)
+        domainProp = circDomainTwo.properties.find {it.type == CircularOne }
+        assert domainProp.name == 'circularOne'
+
+        def domainObject = CircularOneChild.build()
+        assert domainObject != null
+        assert domainObject.circularTwo.circularOne ==  domainObject
+    }
+
+    @Test
     void testEmbeddedProperties() {
         def domainArtefact = registerDomainClass(EmbeddedOwner)
         buildTestDataService.decorateWithMethods(domainArtefact)
@@ -156,6 +182,10 @@ class CircularOne extends BaseMock {
     CircularTwo circularTwo
 
     public static create() { CircularOne.newInstance() }
+}
+
+class CircularOneChild extends CircularOne {
+    public static create() { CircularOneChild.newInstance() }
 }
 
 class CircularTwo extends BaseMock {

--- a/build-test-data/src/groovy/grails/buildtestdata/CircularCheckList.groovy
+++ b/build-test-data/src/groovy/grails/buildtestdata/CircularCheckList.groovy
@@ -5,6 +5,14 @@ class CircularCheckList extends LinkedHashMap {
     def update(domain, force = false) {
         if (force || !this[domain.class.name]) {
             this[domain.class.name] = domain // should short circuit circular references
+
+            Class clazz = domain.class.superclass
+            while (clazz != Object) {
+                if (DomainUtil.getDomainArtefact(clazz) != null) {
+                    this[clazz.name] = domain
+                }
+                clazz = clazz.superclass
+            }
         }
     }
 }


### PR DESCRIPTION
Build test data does not handle circular references with non-trivial class hierarchies. 

Given:

``` groovy
class CircularOne {
    CircularTwo circularTwo
}

class CircularOneChild extends CircularOne {
}

class CircularTwo extends BaseMock {
    CircularOne circularOne
}
```

`CircularOne.build()` will create a new `CircularOne` that has a `CircularTwo` that points back to that same instance of `CircularOne`. But `CircularOneChild.build()` will create a `CircularTwo` that creates and points to a new `CircularOne` that then points that same instance of `CircularTwo`.

This happens because the the circular check list logic relies on a `CircularCheckList` that extends hashmap with keys consisting of the full qualified class name. Changing that implementation to additionally add super classes that are also domain classes will result in multiple entries that will then be found by the relationships in the circular check.
