### PR TITLE
Added support for java.sql.Timestamp

### DIFF
--- a/baseTests/test/integration/DomainTestDataServiceDateTests.groovy
+++ b/baseTests/test/integration/DomainTestDataServiceDateTests.groovy
@@ -117,6 +117,23 @@ class DomainTestDataServiceDateTests extends DomainTestDataServiceBase {
         assert domainObject.monetaryValue != null
         assert 2.0 == domainObject.monetaryValue.amount
         assert domainObject.monetaryValue.currency != null
-    } 
+    }
+
+    @Test
+    void testTimestamp() {
+        def domainClass = createDomainClass("""
+            class TestDomain {
+                Long id
+                Long version
+                java.sql.Timestamp testProperty
+           }
+        """)
+
+        def domainObject = domainClass.build()
+
+        assert domainObject != null
+        assert domainObject.testProperty != null
+        assert domainObject.testProperty instanceof java.sql.Timestamp
+    }
 
 }

--- a/build-test-data/src/groovy/grails/buildtestdata/handler/NullableConstraintHandler.groovy
+++ b/build-test-data/src/groovy/grails/buildtestdata/handler/NullableConstraintHandler.groovy
@@ -44,6 +44,8 @@ class NullableConstraintHandler implements ConstraintHandler {
                 return new java.sql.Date(new Date().time)
             case java.sql.Time:
                 return new java.sql.Time(new Date().time)
+            case java.sql.Timestamp:
+                return new java.sql.Timestamp(new Date().time)
             case Date:
                 return new Date()
             case Boolean:


### PR DESCRIPTION
While using this great plugin just realized that it was throwing a GroovyCastException while building a domain object that contained fields of type java.sql.Timestamp.

```
org.codehaus.groovy.runtime.typehandling.GroovyCastException: Cannot cast object 'Fri Oct 03 15:28:24 COT 2014' with class 'java.util.Date' to class 'java.sql.Timestamp'
    at grails.buildtestdata.handler.NullableConstraintHandler.handle(NullableConstraintHandler.groovy:25)
    at grails.buildtestdata.DomainInstanceBuilder.createMissingProperty(DomainInstanceBuilder.groovy:198)
    at grails.buildtestdata.DomainInstanceBuilder.populateInstance(DomainInstanceBuilder.groovy:158)
    at grails.buildtestdata.DomainInstanceBuilder.build(DomainInstanceBuilder.groovy:136)
    at grails.buildtestdata.DomainInstanceBuilder.build(DomainInstanceBuilder.groovy:135)
```

Added a straigthforward modification so this datatype is supported.
