### PR TITLE
Add option to specify a base package to scan for domains

### DIFF
--- a/build-test-data/src/main/groovy/grails/buildtestdata/TestDataConfigurationHolder.groovy
+++ b/build-test-data/src/main/groovy/grails/buildtestdata/TestDataConfigurationHolder.groovy
@@ -121,4 +121,8 @@ class TestDataConfigurationHolder {
         }
         return propertyValues
     }
+
+    static String getDomainBasePackage() {
+        return configFile?.testDataConfig?.domainBasePackage ?: null
+    }
 }

--- a/build-test-data/src/main/groovy/grails/buildtestdata/mixin/MockDomainHelper.groovy
+++ b/build-test-data/src/main/groovy/grails/buildtestdata/mixin/MockDomainHelper.groovy
@@ -231,7 +231,8 @@ class MockDomainHelper {
             provider.addIncludeFilter(new AssignableTypeFilter(domainClass.getClazz()))
 
             // Scan all packages
-            Set<BeanDefinition> components = provider.findCandidateComponents("")
+            String domainBasePackage = TestDataConfigurationHolder.getDomainBasePackage() ?: ""
+            Set<BeanDefinition> components = provider.findCandidateComponents(domainBasePackage)
             for (BeanDefinition it in components) {
                 Class subClass = grailsApplication.classLoader.loadClass(it.beanClassName)
 


### PR DESCRIPTION
In a unit test, a list of domain classes to mock can be specified. That initial list is then resolved into a full list including any required objects, subclasses, and parent classes. If subclasses for an abstract domain need to be found, the entire classpath is searched for components assignable from any given abstract parent class.

This is very expensive, so to improve performance, it would be great if a base package could be set to scan from, thus reducing the time to scan for subclasses.

Configuration in `TestDataConfig` would look like the following:
```
testDataConfig {
    domainBasePackage = "my.domain.package"
}
```