### PR TITLE
binary compatibility with GORM 6.0

### DIFF
--- a/plugin/src/main/groovy/grails/buildtestdata/DomainInstanceBuilder.groovy
+++ b/plugin/src/main/groovy/grails/buildtestdata/DomainInstanceBuilder.groovy
@@ -1,6 +1,7 @@
 package grails.buildtestdata
 
 import grails.buildtestdata.handler.ExampleConstraintHandler
+import grails.buildtestdata.handler.SizeConstraintHandler
 import grails.databinding.DataBinder
 import grails.databinding.SimpleDataBinder
 import grails.databinding.SimpleMapDataBindingSource
@@ -162,7 +163,7 @@ class DomainInstanceBuilder {
     void applyBiDirectionManyToOnes(GormEntity domainInstance) {
         PersistentEntity defDomain = DomainUtil.getPersistentEntity(domainInstance.class)
         for (Association association in defDomain.associations) {
-            Object value = association.reader.read(domainInstance)
+            Object value = association.owner.reflector.getPropertyReader(association.name).read(domainInstance)
             if (association instanceof ManyToOne && value instanceof GormEntity) {
                 ManyToOne manyToOneProp = association as ManyToOne
                 GormEntity owningObject = value as GormEntity
@@ -201,7 +202,7 @@ class DomainInstanceBuilder {
     Object createProperty(GormEntity domainInstance, String propertyName, ConstrainedProperty constrainedProperty, CircularCheckList circularCheckList) {
         log.debug("Building value for {}.{}", domainInstance?.class?.name, propertyName)
 
-        sortedConstraints(constrainedProperty.appliedConstraints).find { Constraint appliedConstraint ->
+        sortedConstraints(SizeConstraintHandler.getAppliedConstraints(constrainedProperty)).find { Constraint appliedConstraint ->
             log.debug("{}.{} constraint, field before adjustment: {}", domainInstance?.class?.name, appliedConstraint?.name, domainInstance?.metaClass?.getProperty(domainInstance, propertyName))
 
             ConstraintHandler handler = ConstraintHandler.handlers[appliedConstraint.name]

--- a/plugin/src/main/groovy/grails/buildtestdata/DomainUtil.groovy
+++ b/plugin/src/main/groovy/grails/buildtestdata/DomainUtil.groovy
@@ -3,6 +3,7 @@ package grails.buildtestdata
 import groovy.transform.CompileStatic
 import org.grails.datastore.mapping.model.PersistentEntity
 import org.grails.datastore.mapping.reflect.ClassPropertyFetcher
+import org.grails.datastore.mapping.reflect.ReflectionUtils
 
 import java.lang.reflect.Modifier
 
@@ -17,7 +18,7 @@ class DomainUtil {
     }
 
     static PersistentEntity getPersistentEntity(Class clazz) {
-        ClassPropertyFetcher.getStaticPropertyValue(clazz, "gormPersistentEntity", PersistentEntity)
+        ClassPropertyFetcher.forClass(clazz).getStaticPropertyValue("gormPersistentEntity", PersistentEntity)
     }
 
     static boolean propertyIsToManyDomainClass(Class clazz) {

--- a/plugin/src/main/groovy/grails/buildtestdata/handler/MinSizeConstraintHandler.groovy
+++ b/plugin/src/main/groovy/grails/buildtestdata/handler/MinSizeConstraintHandler.groovy
@@ -23,7 +23,7 @@ class MinSizeConstraintHandler extends AbstractConstraintHandler {
 
         padMinSize(
             domain,
-            constrainedProperty.appliedConstraints,
+            SizeConstraintHandler.getAppliedConstraints(constrainedProperty),
             propertyName,
             propertyValue,
             minSizeConstraint.minSize,

--- a/plugin/src/main/groovy/grails/buildtestdata/handler/NullableConstraintHandler.groovy
+++ b/plugin/src/main/groovy/grails/buildtestdata/handler/NullableConstraintHandler.groovy
@@ -112,7 +112,7 @@ class NullableConstraintHandler extends AbstractConstraintHandler {
         // Ensure we don't loop on this domain
         circularCheckList.update(domain)
 
-        if (domainProp instanceof OneToOne || propertyFetcher.getStaticPropertyValue(domain.getClass(), 'embedded', Collection)?.contains(propertyName)) {
+        if (domainProp instanceof OneToOne || propertyFetcher.getStaticPropertyValue('embedded', Collection)?.contains(propertyName)) {
             if (circularCheckList[constrainedProperty?.propertyType?.name]) {
                 setProperty(domain, propertyName, circularCheckList[constrainedProperty?.propertyType?.name])
             }

--- a/plugin/src/main/groovy/grails/buildtestdata/handler/SizeConstraintHandler.groovy
+++ b/plugin/src/main/groovy/grails/buildtestdata/handler/SizeConstraintHandler.groovy
@@ -3,9 +3,13 @@ package grails.buildtestdata.handler
 import grails.buildtestdata.CircularCheckList
 import grails.gorm.validation.ConstrainedProperty
 import grails.gorm.validation.Constraint
+import grails.gorm.validation.DefaultConstrainedProperty
+import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
+import groovy.transform.PackageScope
 import org.grails.datastore.gorm.GormEntity
 import org.grails.datastore.gorm.validation.constraints.SizeConstraint
+import org.grails.validation.ConstrainedDelegate
 
 @CompileStatic
 class SizeConstraintHandler extends AbstractConstraintHandler {
@@ -16,7 +20,7 @@ class SizeConstraintHandler extends AbstractConstraintHandler {
 
         MinSizeConstraintHandler.padMinSize(
             domain,
-            constrainedProperty.appliedConstraints,
+            getAppliedConstraints(constrainedProperty),
             propertyName,
             getProperty(domain, propertyName),
             range.from,
@@ -24,5 +28,15 @@ class SizeConstraintHandler extends AbstractConstraintHandler {
         )
 
         MaxSizeConstraintHandler.padMaxSize(domain, propertyName, getProperty(domain, propertyName), range.to)
+    }
+
+    @CompileDynamic static Collection<Constraint> getAppliedConstraints(ConstrainedProperty property) {
+        if (property instanceof DefaultConstrainedProperty) {
+            return property.appliedConstraints
+        }
+        if (property instanceof ConstrainedDelegate) {
+            return property.appliedConstraints
+        }
+        throw new IllegalArgumentException("ConstrainedProperty of unknown type: ${property.getClass()}")
     }
 }


### PR DESCRIPTION
As a maintainer, I would like to first migrate tests and then migrate Grails from version 3.3 to 3.2. I was able to migrate from old Grails testing framework to the new one and from this plugin version 3.0.1 to 3.3.0.RC1 but I find out there is a minor binary incompatibility in the code. As the incompatibility is really in couple of lines I was able to backport these lines to be aligned with 6.0.x GORM line. All the tests were running in similar way but I'm facing #94 now.