### PR TITLE
add a UnitTestDomainBuilder and TestData helper class. made some fiel…

### DIFF
--- a/plugin/src/main/groovy/grails/buildtestdata/TestData.groovy
+++ b/plugin/src/main/groovy/grails/buildtestdata/TestData.groovy
@@ -1,0 +1,27 @@
+package grails.buildtestdata
+
+class TestData {
+
+    static <T> T build(Class<T> clazz, Map<String, Object> propValues = [:]) {
+        DomainInstanceBuilder builder = DomainInstanceRegistry.lookup(clazz)
+        builder.build(propValues) as T
+    }
+
+    static <T> T buildWithoutSave(Class<T> clazz, Map<String, Object> propValues = [:]) {
+        DomainInstanceBuilder builder = DomainInstanceRegistry.lookup(clazz)
+        builder.buildWithoutSave(propValues) as T
+    }
+
+    static <T> T buildLazy(Class<T> clazz, Map<String, Object> propValues = [:]) {
+        DomainInstanceBuilder builder = DomainInstanceRegistry.lookup(clazz)
+        (builder.findExisting(propValues) ?: builder.build(propValues)) as T
+    }
+
+    static void loadTestDataConfig() {
+        TestDataConfigurationHolder.loadTestDataConfig()
+    }
+
+    static void clearCache() {
+        DomainInstanceRegistry.clear()
+    }
+}

--- a/plugin/src/main/groovy/grails/buildtestdata/TestData.groovy
+++ b/plugin/src/main/groovy/grails/buildtestdata/TestData.groovy
@@ -1,20 +1,42 @@
 package grails.buildtestdata
 
+/**
+ * static helpers to build a domain instance with test data
+ */
 class TestData {
 
-    static <T> T build(Class<T> clazz, Map<String, Object> propValues = [:]) {
-        DomainInstanceBuilder builder = DomainInstanceRegistry.lookup(clazz)
-        builder.build(propValues) as T
+    /**
+     * builds and saves and instance of the domain entity
+     *
+     * @param entityClass the domain class to use
+     * @param data properties to set on the entity instance before it tries to build tests data
+     * @return the built and saved entity instance
+     */
+    static <T> T build(Class<T> entityClass, Map<String, Object> data = [:]) {
+        DomainInstanceBuilder builder = DomainInstanceRegistry.lookup(entityClass)
+        builder.build(data) as T
     }
 
-    static <T> T buildWithoutSave(Class<T> clazz, Map<String, Object> propValues = [:]) {
-        DomainInstanceBuilder builder = DomainInstanceRegistry.lookup(clazz)
-        builder.buildWithoutSave(propValues) as T
+    /**
+     * Uses the cached entity if it exists, otherwise build a new one
+     * @param entityClass the domain class to use
+     * @param data properties to set on the entity instance before it tries to build tests data
+     * @return the built unsaved entity instance
+     */
+    static <T> T buildWithoutSave(Class<T> entityClass, Map<String, Object> data = [:]) {
+        DomainInstanceBuilder builder = DomainInstanceRegistry.lookup(entityClass)
+        builder.buildWithoutSave(data) as T
     }
 
-    static <T> T buildLazy(Class<T> clazz, Map<String, Object> propValues = [:]) {
-        DomainInstanceBuilder builder = DomainInstanceRegistry.lookup(clazz)
-        (builder.findExisting(propValues) ?: builder.build(propValues)) as T
+    /**
+     * Uses the cached entity if it exists, otherwise build a new one
+     * @param entityClass the domain class to use
+     * @param data properties to set on the entity instance before it tries to build tests data
+     * @return the built and saved entity intance
+     */
+    static <T> T buildWithCache(Class<T> entityClass, Map<String, Object> data = [:]) {
+        DomainInstanceBuilder builder = DomainInstanceRegistry.lookup(entityClass)
+        (builder.findExisting(data) ?: builder.build(data)) as T
     }
 
     static void loadTestDataConfig() {

--- a/plugin/src/main/groovy/grails/buildtestdata/TestDataBuilder.groovy
+++ b/plugin/src/main/groovy/grails/buildtestdata/TestDataBuilder.groovy
@@ -5,7 +5,7 @@ import org.junit.AfterClass
 import org.junit.BeforeClass
 
 /**
- * Integration tests should implement this trait to add build-test-data functionality
+ * Integration tests can implement this trait to add build-test-data functionality
  */
 @CompileStatic
 @SuppressWarnings("GroovyUnusedDeclaration")
@@ -20,7 +20,7 @@ trait TestDataBuilder {
     }
 
     public <T> T buildLazy(Class<T> clazz, Map<String, Object> propValues = [:]) {
-        TestData.buildLazy(clazz, propValues)
+        TestData.buildWithCache(clazz, propValues)
     }
 
     /**

--- a/plugin/src/main/groovy/grails/buildtestdata/TestDataBuilder.groovy
+++ b/plugin/src/main/groovy/grails/buildtestdata/TestDataBuilder.groovy
@@ -10,19 +10,17 @@ import org.junit.BeforeClass
 @CompileStatic
 @SuppressWarnings("GroovyUnusedDeclaration")
 trait TestDataBuilder {
+
     public <T> T build(Class<T> clazz, Map<String, Object> propValues = [:]) {
-        DomainInstanceBuilder builder = DomainInstanceRegistry.lookup(clazz)
-        builder.build(propValues) as T
+        TestData.build(clazz, propValues)
     }
 
     public <T> T buildWithoutSave(Class<T> clazz, Map<String, Object> propValues = [:]) {
-        DomainInstanceBuilder builder = DomainInstanceRegistry.lookup(clazz)
-        builder.buildWithoutSave(propValues) as T
+        TestData.buildWithoutSave(clazz, propValues)
     }
 
     public <T> T buildLazy(Class<T> clazz, Map<String, Object> propValues = [:]) {
-        DomainInstanceBuilder builder = DomainInstanceRegistry.lookup(clazz)
-        (builder.findExisting(propValues) ?: builder.build(propValues)) as T
+        TestData.buildLazy(clazz, propValues)
     }
 
     /**

--- a/plugin/src/main/groovy/grails/buildtestdata/UnitTestDataBuilder.groovy
+++ b/plugin/src/main/groovy/grails/buildtestdata/UnitTestDataBuilder.groovy
@@ -35,7 +35,7 @@ trait UnitTestDataBuilder extends DataTest implements TestDataBuilder {
         }
     }
 
-    private Class[] expandSubclasses(Class<?>... classes) {
+    Class[] expandSubclasses(Class<?>... classes) {
         classes.collectMany { Class clazz ->
             List<Class> result = [clazz]
             Class subClass = DomainUtil.findConcreteSubclass(clazz)
@@ -46,7 +46,7 @@ trait UnitTestDataBuilder extends DataTest implements TestDataBuilder {
         } as Class[]
     }
 
-    private void resolveDependencyGraph(Set<Class> mockedList, Class<?>... domainClassesToMock) {
+    void resolveDependencyGraph(Set<Class> mockedList, Class<?>... domainClassesToMock) {
         // First mock these domains so they are registered with Grails
         super.mockDomains(domainClassesToMock)
         mockedList.addAll(domainClassesToMock)

--- a/plugin/src/main/groovy/grails/buildtestdata/UnitTestDomainBuilder.groovy
+++ b/plugin/src/main/groovy/grails/buildtestdata/UnitTestDomainBuilder.groovy
@@ -10,7 +10,7 @@ import org.springframework.core.GenericTypeResolver
 trait UnitTestDomainBuilder<D> implements UnitTestDataBuilder {
 
     private D domainInstance
-    static Class<D> domainClass
+    private static Class<D> entityClass
 
     /**
      * @return An instance of the domain class
@@ -18,34 +18,37 @@ trait UnitTestDomainBuilder<D> implements UnitTestDataBuilder {
     D getDomain() {
         if (domainInstance == null) {
             //use buildWithoutSave to keep it consitent with how DomainUnitTest does it
-            domainInstance = TestData.buildWithoutSave(getDomainUnderTest())
+            this.domainInstance = TestData.buildWithoutSave(getEntityClass())
         }
         domainInstance
+    }
+
+    /**
+     * same as getDomain()
+     */
+    D getEntity() {
+        getDomain()
     }
 
     /** this is called by the {@link org.grails.testing.gorm.spock.DataTestSetupSpecInterceptor} */
     @Override
     Class<?>[] getDomainClassesToMock() {
-        [getDomainUnderTest()].toArray(Class)
+        [getEntityClass()].toArray(Class)
     }
 
-    Class<D> getDomainUnderTest() {
-        if (!domainClass)
-            this.domainClass = (Class<D>) GenericTypeResolver.resolveTypeArgument(getClass(), UnitTestDomainBuilder.class)
+    Class<D> getEntityClass() {
+        if (!entityClass)
+            this.entityClass = (Class<D>) GenericTypeResolver.resolveTypeArgument(getClass(), UnitTestDomainBuilder.class)
 
-        return domainClass
+        return entityClass
     }
 
     D build(Map<String, Object> propValues = [:]) {
-        TestData.build(getDomainUnderTest(), propValues)
+        TestData.build(getEntityClass(), propValues)
     }
 
     D buildWithoutSave(Map<String, Object> propValues = [:]) {
-        TestData.buildWithoutSave(getDomainUnderTest(), propValues)
-    }
-
-    D buildLazy(Map<String, Object> propValues = [:]) {
-        TestData.buildLazy(getDomainUnderTest(), propValues)
+        TestData.buildWithoutSave(getEntityClass(), propValues)
     }
 
 }

--- a/plugin/src/main/groovy/grails/buildtestdata/UnitTestDomainBuilder.groovy
+++ b/plugin/src/main/groovy/grails/buildtestdata/UnitTestDomainBuilder.groovy
@@ -1,0 +1,51 @@
+package grails.buildtestdata
+
+import groovy.transform.CompileStatic
+import org.springframework.core.GenericTypeResolver
+
+/**
+ * Works like the Grails Testing Support's grails.testing.gorm.DomainUnitTest for testing a single entity
+ */
+@CompileStatic
+trait UnitTestDomainBuilder<D> implements UnitTestDataBuilder {
+
+    private D domainInstance
+    static Class<D> domainClass
+
+    /**
+     * @return An instance of the domain class
+     */
+    D getDomain() {
+        if (domainInstance == null) {
+            //use buildWithoutSave to keep it consitent with how DomainUnitTest does it
+            domainInstance = TestData.buildWithoutSave(getDomainUnderTest())
+        }
+        domainInstance
+    }
+
+    /** this is called by the {@link org.grails.testing.gorm.spock.DataTestSetupSpecInterceptor} */
+    @Override
+    Class<?>[] getDomainClassesToMock() {
+        [getDomainUnderTest()].toArray(Class)
+    }
+
+    Class<D> getDomainUnderTest() {
+        if (!domainClass)
+            this.domainClass = (Class<D>) GenericTypeResolver.resolveTypeArgument(getClass(), UnitTestDomainBuilder.class)
+
+        return domainClass
+    }
+
+    D build(Map<String, Object> propValues = [:]) {
+        TestData.build(getDomainUnderTest(), propValues)
+    }
+
+    D buildWithoutSave(Map<String, Object> propValues = [:]) {
+        TestData.buildWithoutSave(getDomainUnderTest(), propValues)
+    }
+
+    D buildLazy(Map<String, Object> propValues = [:]) {
+        TestData.buildLazy(getDomainUnderTest(), propValues)
+    }
+
+}

--- a/plugin/src/main/groovy/grails/buildtestdata/traits/BuildTestDataEntity.groovy
+++ b/plugin/src/main/groovy/grails/buildtestdata/traits/BuildTestDataEntity.groovy
@@ -1,24 +1,21 @@
 package grails.buildtestdata.traits
 
-import grails.buildtestdata.DomainInstanceBuilder
-import grails.buildtestdata.DomainInstanceRegistry
+import grails.buildtestdata.TestData
 import groovy.transform.CompileStatic
 import org.grails.datastore.gorm.GormEntity
 
 @CompileStatic
 trait BuildTestDataEntity<D extends GormEntity<D>> {
+
     static D build(Map<String, Object> propValues = [:]) {
-        DomainInstanceBuilder builder = DomainInstanceRegistry.lookup(this)
-        builder.build(propValues) as D
+        TestData.build(this, propValues) as D
     }
 
     static D buildWithoutSave(Map<String, Object> propValues = [:]) {
-        DomainInstanceBuilder builder = DomainInstanceRegistry.lookup(this)
-        builder.buildWithoutSave(propValues) as D
+        TestData.buildWithoutSave(this, propValues) as D
     }
 
     static D buildLazy(Map<String, Object> propValues = [:]) {
-        DomainInstanceBuilder builder = DomainInstanceRegistry.lookup(this)
-        (builder.findExisting(propValues) ?: builder.build(propValues)) as D
+        TestData.buildLazy(this, propValues) as D
     }
 }

--- a/plugin/src/main/groovy/grails/buildtestdata/traits/BuildTestDataEntity.groovy
+++ b/plugin/src/main/groovy/grails/buildtestdata/traits/BuildTestDataEntity.groovy
@@ -16,6 +16,6 @@ trait BuildTestDataEntity<D extends GormEntity<D>> {
     }
 
     static D buildLazy(Map<String, Object> propValues = [:]) {
-        TestData.buildLazy(this, propValues) as D
+        TestData.buildWithCache(this, propValues) as D
     }
 }

--- a/plugin/src/test/groovy/grails/buildtestdata/UnitTestDomainBuilderTest.groovy
+++ b/plugin/src/test/groovy/grails/buildtestdata/UnitTestDomainBuilderTest.groovy
@@ -1,0 +1,64 @@
+package grails.buildtestdata
+
+import spock.lang.Shared
+import spock.lang.Specification
+
+class UnitTestDomainBuilderTest extends Specification implements UnitTestDomainBuilder<SampleUnitTestDomain>{
+    @Shared int id
+
+    void "test basic persistence mocking"() {
+        setup:
+        build().save()
+        build().save()
+
+        expect:
+        SampleUnitTestDomain.count() == 2
+        SampleUnitTestDomainChild.count() == 2
+    }
+
+    void "test domain instance"() {
+        setup:
+        id = System.identityHashCode(domain)
+
+        expect:
+        domain != null
+        domain.hashCode() == id
+        domain.name != null
+
+        when:
+        domain.name = 'Robert'
+
+        then:
+        domain.name == 'Robert'
+    }
+
+    void "test props"() {
+        when:
+        def u = build(name: 'bill')
+        domain.name = 'bob'
+
+        then:
+        u.name == 'bill'
+        domain.name == 'bob'
+    }
+
+    void "test we get a new domain each time"() {
+        expect:
+        domain != null
+        domain.name == 'name'
+        domain.child
+        System.identityHashCode(domain) != id
+    }
+
+}
+
+@grails.persistence.Entity
+class SampleUnitTestDomain {
+    String name
+    SampleUnitTestDomainChild child
+}
+
+@grails.persistence.Entity
+class SampleUnitTestDomainChild {
+    String name
+}

--- a/plugin/src/test/groovy/hibernate/specs/HibDomainClassSpec.groovy
+++ b/plugin/src/test/groovy/hibernate/specs/HibDomainClassSpec.groovy
@@ -1,12 +1,12 @@
 package hibernate.specs
 
-import grails.buildtestdata.TestDataBuilder
 import grails.test.hibernate.HibernateSpec
 import hibernate.domains.Bar
 import hibernate.domains.Foo
+import static grails.buildtestdata.TestData.*
 
 //don't use trait on this one, use the TestDataBuilder
-class HibDomainClassSpec extends HibernateSpec implements TestDataBuilder {
+class HibDomainClassSpec extends HibernateSpec{
 
     //dont' need to give it Bar as it will see its an association and mock it
     List<Class> getDomainClasses() {[ Foo ]}
@@ -21,7 +21,7 @@ class HibDomainClassSpec extends HibernateSpec implements TestDataBuilder {
     void "test that Bar got mocked and saved"() {
 
         when: "buildLazy should pick up the one thats already there from setupSpec"
-        def bar = buildLazy(Bar) //should pick up the one thats already there
+        def bar = buildWithCache(Bar) //should pick up the one thats already there
 
         then: "the id should be 1 as it was saved already"
         bar.id == 1
@@ -43,7 +43,7 @@ class HibDomainClassSpec extends HibernateSpec implements TestDataBuilder {
 
     void "round 2"() {
         when: "buildLazy is called but will create a new one"
-        def foo = buildLazy(Foo)
+        def foo = buildWithCache(Foo)
         //build(Foo)
 
         then: "a new Foo was saved since the build was called in another test and not in setupSpec"

--- a/plugin/src/test/groovy/hibernate/specs/HibernateSpecSpec.groovy
+++ b/plugin/src/test/groovy/hibernate/specs/HibernateSpecSpec.groovy
@@ -1,13 +1,14 @@
 package hibernate.specs
 
 import grails.test.hibernate.HibernateSpec
+import static grails.buildtestdata.TestData.build
 
 class HibernateSpecSpec extends HibernateSpec {
 
     //HibernateSpec scans the package the test sits in. It will automatically find the Baz
     void "test hibernate spec with automatic scan"() {
         when:
-        Baz.build()
+        build(Baz)
 
         then:
         def baz1 = Baz.findById(1)


### PR DESCRIPTION
…ds/method public so they can be overriden more easily.
closes #100 
connect #96 <- might take care of this as the static method on TestData can be used easily now by importing them as done in the hibernateSpecSpec