### PR TITLE
Fill the subClassCache with the abstract defaults from the config file

### DIFF
--- a/build-test-data/build.gradle
+++ b/build-test-data/build.gradle
@@ -16,7 +16,7 @@ plugins {
     id "com.jfrog.bintray" version "1.2"
 }
 
-version "3.0.1"
+version "3.0.2"
 group "org.grails.plugins"
 
 apply plugin: 'maven-publish'


### PR DESCRIPTION
This helps prevent having to scan for subclasses, which is very expensive

Suggested fix for #81 