### PR TITLE
rename BuildDataTest til BuildDataUnitTest to avoid confusion as to w…

### DIFF
--- a/docs/src/asciidoc/testdataconfig.adoc
+++ b/docs/src/asciidoc/testdataconfig.adoc
@@ -69,7 +69,7 @@ You are not required to have a TestDataConfig.groovy file.
 === Test Specific Config
 It's also possible to specify a config that is used during a particular test.
 
-Your test should implement the `TestDataBuilder` for integration tests or `BuildDataTest` for unit tests. Just override the `doWithTestDataConfig` method and return a Closure just like your `TestDataConfig.groovy`:
+Your test should implement the `TestDataBuilder` for integration tests or `BuildDataUnitTest` for unit tests. Just override the `doWithTestDataConfig` method and return a Closure just like your `TestDataConfig.groovy`:
 ```groovy
     Closure doWithTestDataConfig() {{->
         testDataConfig {
@@ -78,7 +78,7 @@ Your test should implement the `TestDataBuilder` for integration tests or `Build
                     name = {-> "Westin" }
                 }
             }
-        }  
+        }
     }}
 ```
 This will merge the config provided from this method with the global configuration (if any) in `TestDataConfig.groovy`.

--- a/docs/src/asciidoc/unittesting.adoc
+++ b/docs/src/asciidoc/unittesting.adoc
@@ -78,10 +78,10 @@ class BookUnitSpec extends Specification implements BuildDataTest {
 }
 ```
 
-NOTE: Even if you are using the `@Build` annotation, you must still implement the `BuildDataTest` trait.
+NOTE: Even if you are using the `@Build` annotation, you must still implement the `BuildDataUnitTest` trait.
 
 === Trait Methods
-The `TestDataBuilder` and therefore the `BuildDataTest` trait adds the builder methods to your test class if you prefer to call them directly.
+The `TestDataBuilder` and therefore the `BuildDataUnitTest` trait adds the builder methods to your test class if you prefer to call them directly.
 These call out to statics in the `TestData` class.
 ```groovy
     public <T> T build(Map args = [:], Class<T> clazz) {

--- a/examples/alternativeConfig/src/test/groovy/alternativeconfig/SimpleSpec.groovy
+++ b/examples/alternativeConfig/src/test/groovy/alternativeconfig/SimpleSpec.groovy
@@ -1,10 +1,10 @@
 package alternativeconfig
 
-import grails.buildtestdata.BuildDataTest
+import grails.buildtestdata.BuildDataUnitTest
 import grails.util.Holders
 import spock.lang.Specification
 
-class SimpleSpec extends Specification implements BuildDataTest {
+class SimpleSpec extends Specification implements BuildDataUnitTest {
     void setupSpec() {
         mockDomains(Simple)
     }

--- a/examples/bookStore/src/test/groovy/base/AbstractDefaultUnitTests.groovy
+++ b/examples/bookStore/src/test/groovy/base/AbstractDefaultUnitTests.groovy
@@ -7,11 +7,11 @@ import abstractclass.AnotherConcreteSubClass
 import abstractclass.ConcreteSubClass
 import grails.buildtestdata.TestData
 import grails.buildtestdata.TestDataConfigurationHolder
-import grails.buildtestdata.BuildDataTest
+import grails.buildtestdata.BuildDataUnitTest
 
 import spock.lang.Specification
 
-class AbstractDefaultUnitTests extends Specification implements BuildDataTest {
+class AbstractDefaultUnitTests extends Specification implements BuildDataUnitTest {
     void setup() {
         TestDataConfigurationHolder.reset()
 

--- a/examples/bookStore/src/test/groovy/base/AbstractRelatedUnitTests.groovy
+++ b/examples/bookStore/src/test/groovy/base/AbstractRelatedUnitTests.groovy
@@ -2,11 +2,11 @@ package base
 
 import abstractclass.ConcreteSubClass
 import abstractclass.RelatedToAbstract
-import grails.buildtestdata.BuildDataTest
+import grails.buildtestdata.BuildDataUnitTest
 import grails.buildtestdata.TestDataConfigurationHolder
 import spock.lang.Specification
 
-class AbstractRelatedUnitTests extends Specification implements BuildDataTest {
+class AbstractRelatedUnitTests extends Specification implements BuildDataUnitTest {
     void setup() {
         TestDataConfigurationHolder.reset()
     }

--- a/examples/bookStore/src/test/groovy/base/BuildLazyUnitTests.groovy
+++ b/examples/bookStore/src/test/groovy/base/BuildLazyUnitTests.groovy
@@ -1,10 +1,10 @@
 package base
 
 import bookstore.Author
-import grails.buildtestdata.BuildDataTest
+import grails.buildtestdata.BuildDataUnitTest
 import spock.lang.Specification
 
-class BuildLazyUnitTests extends Specification implements BuildDataTest {
+class BuildLazyUnitTests extends Specification implements BuildDataUnitTest {
 
     void setupSpec() {
         mockDomains(Author)

--- a/examples/bookStore/src/test/groovy/base/ConfigWithoutResetUnitTests.groovy
+++ b/examples/bookStore/src/test/groovy/base/ConfigWithoutResetUnitTests.groovy
@@ -2,10 +2,10 @@ package base
 
 import config.Article
 import grails.buildtestdata.TestDataConfigurationHolder
-import grails.buildtestdata.BuildDataTest
+import grails.buildtestdata.BuildDataUnitTest
 import spock.lang.Specification
 
-class ConfigWithoutResetUnitTests extends Specification implements BuildDataTest {
+class ConfigWithoutResetUnitTests extends Specification implements BuildDataUnitTest {
     void setup() {
         mockDomain(Article)
     }

--- a/examples/bookStore/src/test/groovy/base/EnumUnitTests.groovy
+++ b/examples/bookStore/src/test/groovy/base/EnumUnitTests.groovy
@@ -4,10 +4,10 @@ import enumtest.Car
 import enumtest.CarStatus
 import enumtest.Door
 import enumtest.DoorStatus
-import grails.buildtestdata.BuildDataTest
+import grails.buildtestdata.BuildDataUnitTest
 import spock.lang.Specification
 
-class EnumUnitTests extends Specification implements BuildDataTest {
+class EnumUnitTests extends Specification implements BuildDataUnitTest {
     void setupSpec() {
         mockDomains(Car, Door)
     }

--- a/examples/bookStore/src/test/groovy/base/LocalScopedConfigUnitTests.groovy
+++ b/examples/bookStore/src/test/groovy/base/LocalScopedConfigUnitTests.groovy
@@ -1,11 +1,11 @@
 package base
 
-import grails.buildtestdata.BuildDataTest
+import grails.buildtestdata.BuildDataUnitTest
 import magazine.Issue
 import magazine.Page
 import spock.lang.Specification
 
-class LocalScopedConfigUnitTests extends Specification implements BuildDataTest {
+class LocalScopedConfigUnitTests extends Specification implements BuildDataUnitTest {
     void setupSpec() {
         mockDomains(Issue, Page)
     }

--- a/examples/bookStore/src/test/groovy/base/MatchesUnitTests.groovy
+++ b/examples/bookStore/src/test/groovy/base/MatchesUnitTests.groovy
@@ -1,10 +1,10 @@
 package base
 
 import bookstore.Invoice
-import grails.buildtestdata.BuildDataTest
+import grails.buildtestdata.BuildDataUnitTest
 import spock.lang.Specification
 
-class MatchesUnitTests extends Specification implements BuildDataTest {
+class MatchesUnitTests extends Specification implements BuildDataUnitTest {
     void setupSpec() {
         mockDomains(Invoice)
     }

--- a/examples/bookStore/src/test/groovy/base/MinSizeUnitTests.groovy
+++ b/examples/bookStore/src/test/groovy/base/MinSizeUnitTests.groovy
@@ -1,10 +1,10 @@
 package base
 
 import bookstore.Address
-import grails.buildtestdata.BuildDataTest
+import grails.buildtestdata.BuildDataUnitTest
 import spock.lang.Specification
 
-class MinSizeUnitTests extends Specification implements BuildDataTest {
+class MinSizeUnitTests extends Specification implements BuildDataUnitTest {
     void setupSpec() {
         mockDomains(Address)
     }

--- a/examples/bookStore/src/test/groovy/base/RelationUnitTests.groovy
+++ b/examples/bookStore/src/test/groovy/base/RelationUnitTests.groovy
@@ -3,7 +3,7 @@ package base
 import bookstore.Author
 import bookstore.Book
 import bookstore.Invoice
-import grails.buildtestdata.BuildDataTest
+import grails.buildtestdata.BuildDataUnitTest
 import human.Arm
 import human.Face
 import magazine.Issue
@@ -11,7 +11,7 @@ import magazine.Page
 
 import spock.lang.Specification
 
-class RelationUnitTests extends Specification implements BuildDataTest {
+class RelationUnitTests extends Specification implements BuildDataUnitTest {
     void setupSpec() {
         mockDomains(Face, Book, Author, Invoice, Page, Issue, Arm)
     }

--- a/examples/bookStore/src/test/groovy/base/RelationUnitTestsUsingBuild.groovy
+++ b/examples/bookStore/src/test/groovy/base/RelationUnitTestsUsingBuild.groovy
@@ -3,7 +3,7 @@ package base
 import bookstore.Author
 import bookstore.Book
 import bookstore.Invoice
-import grails.buildtestdata.BuildDataTest
+import grails.buildtestdata.BuildDataUnitTest
 import grails.buildtestdata.mixin.Build
 import human.Arm
 import human.Face
@@ -12,7 +12,7 @@ import magazine.Page
 import spock.lang.Specification
 
 @Build([Arm, Face, Book, Author, Invoice, Page])
-class RelationUnitTestsUsingBuild extends Specification implements BuildDataTest {
+class RelationUnitTestsUsingBuild extends Specification implements BuildDataUnitTest {
     void testOneToOneCascades() {
         when:
         def domainObject = Face.build()

--- a/examples/bookStore/src/test/groovy/base/StandaloneUnitTests.groovy
+++ b/examples/bookStore/src/test/groovy/base/StandaloneUnitTests.groovy
@@ -1,10 +1,10 @@
 package base
 
-import grails.buildtestdata.BuildDataTest
+import grails.buildtestdata.BuildDataUnitTest
 import spock.lang.Specification
 import standalone.Standalone
 
-class StandaloneUnitTests extends Specification implements BuildDataTest {
+class StandaloneUnitTests extends Specification implements BuildDataUnitTest {
     @Override
     Class[] getDomainClassesToMock() {
         [Standalone]

--- a/examples/bookStore/src/test/groovy/base/SubclassUnitTests.groovy
+++ b/examples/bookStore/src/test/groovy/base/SubclassUnitTests.groovy
@@ -1,12 +1,12 @@
 package base
 
-import grails.buildtestdata.BuildDataTest
+import grails.buildtestdata.BuildDataUnitTest
 import spock.lang.Specification
 import subclassing.RelatedClass
 import subclassing.SubClass
 import subclassing.SuperClass
 
-class SubclassUnitTests extends Specification implements BuildDataTest {
+class SubclassUnitTests extends Specification implements BuildDataUnitTest {
     void setupSpec() {
         mockDomains(SubClass, RelatedClass, SuperClass)
     }

--- a/examples/bookStore/src/test/groovy/base/TestDataConfigUnitTests.groovy
+++ b/examples/bookStore/src/test/groovy/base/TestDataConfigUnitTests.groovy
@@ -3,14 +3,14 @@ package base
 import bookstore.Author
 import config.Article
 import config.Hotel
-import grails.buildtestdata.BuildDataTest
+import grails.buildtestdata.BuildDataUnitTest
 import grails.buildtestdata.TestDataConfigurationHolder
 import spock.lang.Specification
 
-class TestDataConfigUnitTests extends Specification implements BuildDataTest {
+class TestDataConfigUnitTests extends Specification implements BuildDataUnitTest {
     void cleanup() {
         // we should reset the config holder when feeding it values in tests as it could cause issues
-        // for other tests later on that are expecting the default config if we do not 
+        // for other tests later on that are expecting the default config if we do not
         TestDataConfigurationHolder.reset()
     }
 

--- a/examples/bookStore/src/test/groovy/base/ToManyBasicTypeSpec.groovy
+++ b/examples/bookStore/src/test/groovy/base/ToManyBasicTypeSpec.groovy
@@ -2,11 +2,11 @@ package base
 
 import bookstore.BookInfo
 import enums.BookType
-import grails.buildtestdata.BuildDataTest
+import grails.buildtestdata.BuildDataUnitTest
 import grails.buildtestdata.TestDataConfigurationHolder
 import spock.lang.Specification
 
-class ToManyBasicTypeSpec extends Specification implements BuildDataTest {
+class ToManyBasicTypeSpec extends Specification implements BuildDataUnitTest {
     void setup() {
         TestDataConfigurationHolder.reset()
     }

--- a/examples/bookStore/src/test/groovy/embedded/EmbeddingUnitTests.groovy
+++ b/examples/bookStore/src/test/groovy/embedded/EmbeddingUnitTests.groovy
@@ -1,10 +1,10 @@
 package embedded
 
-import grails.buildtestdata.BuildDataTest
+import grails.buildtestdata.BuildDataUnitTest
 import grails.buildtestdata.TestDataConfigurationHolder
 import spock.lang.Specification
 
-class EmbeddingUnitTests extends Specification implements BuildDataTest {
+class EmbeddingUnitTests extends Specification implements BuildDataUnitTest {
     @Override
     Class[] getDomainClassesToMock() {
         [Embedding]

--- a/examples/bookStore/src/test/groovy/hibernate4/PaintingBuildSpec.groovy
+++ b/examples/bookStore/src/test/groovy/hibernate4/PaintingBuildSpec.groovy
@@ -1,16 +1,16 @@
 package hibernate4
 
-import grails.buildtestdata.BuildDataTest
+import grails.buildtestdata.BuildDataUnitTest
 import spock.lang.Specification
 
-class PaintingBuildSpec extends Specification implements BuildDataTest {
+class PaintingBuildSpec extends Specification implements BuildDataUnitTest {
     @Override
     Class[] getDomainClassesToMock() {
         [Painting]
     }
 
     void "building a Painting builds Gallery and Painter"() {
-        when: 
+        when:
         Painting painting = build(Painting, [title: "The Hunters in the Snow"])
 
         then:

--- a/examples/bookStore/src/test/groovy/list/EstablishedAuthorUnitTests.groovy
+++ b/examples/bookStore/src/test/groovy/list/EstablishedAuthorUnitTests.groovy
@@ -1,10 +1,10 @@
 package list
 
 import bookstore.EstablishedAuthor
-import grails.buildtestdata.BuildDataTest
+import grails.buildtestdata.BuildDataUnitTest
 import spock.lang.Specification
 
-class EstablishedAuthorUnitTests extends Specification implements BuildDataTest {
+class EstablishedAuthorUnitTests extends Specification implements BuildDataUnitTest {
     @Override
     Class[] getDomainClassesToMock() {
         [EstablishedAuthor]

--- a/examples/bookStore/src/test/groovy/list/SantaUnitTests.groovy
+++ b/examples/bookStore/src/test/groovy/list/SantaUnitTests.groovy
@@ -1,9 +1,9 @@
 package list
 
-import grails.buildtestdata.BuildDataTest
+import grails.buildtestdata.BuildDataUnitTest
 import spock.lang.Specification
 
-class SantaUnitTests extends Specification implements BuildDataTest {
+class SantaUnitTests extends Specification implements BuildDataUnitTest {
     @Override
     Class[] getDomainClassesToMock() {
         [Santa, Child]

--- a/examples/bookStore/src/test/groovy/triangle/TriangleRelationshipUnitTests.groovy
+++ b/examples/bookStore/src/test/groovy/triangle/TriangleRelationshipUnitTests.groovy
@@ -1,9 +1,9 @@
 package triangle
 
-import grails.buildtestdata.BuildDataTest
+import grails.buildtestdata.BuildDataUnitTest
 import spock.lang.Specification
 
-class TriangleRelationshipUnitTests extends Specification implements BuildDataTest {
+class TriangleRelationshipUnitTests extends Specification implements BuildDataUnitTest {
     @Override
     Class[] getDomainClassesToMock() {
         [Worker, Manager, Director]

--- a/plugin/src/main/groovy/grails/buildtestdata/BuildDataUnitTest.groovy
+++ b/plugin/src/main/groovy/grails/buildtestdata/BuildDataUnitTest.groovy
@@ -13,7 +13,7 @@ import groovy.transform.CompileStatic
  */
 @CompileStatic
 @SuppressWarnings("GroovyUnusedDeclaration")
-trait BuildDataTest extends DependencyDataTest implements TestDataBuilder {
+trait BuildDataUnitTest extends DependencyDataTest implements TestDataBuilder {
 
     @Override
     void mockDomains(Class<?>... domainClassesToMock) {

--- a/plugin/src/main/groovy/grails/buildtestdata/BuildDomainTest.groovy
+++ b/plugin/src/main/groovy/grails/buildtestdata/BuildDomainTest.groovy
@@ -10,7 +10,7 @@ import org.springframework.core.GenericTypeResolver
  * implement BuildDomainTest<Book> and it will take care of mocking the Author for you.
  */
 @CompileStatic
-trait BuildDomainTest<D> implements BuildDataTest {
+trait BuildDomainTest<D> implements BuildDataUnitTest {
 
     private D entity
     private static Class<D> entityClass

--- a/plugin/src/main/groovy/grails/buildtestdata/UnitTestDataBuilder.groovy
+++ b/plugin/src/main/groovy/grails/buildtestdata/UnitTestDataBuilder.groovy
@@ -1,6 +1,6 @@
 package grails.buildtestdata
 
 @Deprecated //use BuildDataTest instead. left in as it was here for 3.3.0-RC1. will keep for one more iteration while users refactor
-trait UnitTestDataBuilder extends BuildDataTest{
+trait UnitTestDataBuilder extends BuildDataUnitTest{
 
 }

--- a/plugin/src/test/groovy/basetests/DomainTestBase.groovy
+++ b/plugin/src/test/groovy/basetests/DomainTestBase.groovy
@@ -1,8 +1,8 @@
 package basetests
 
-import grails.buildtestdata.BuildDataTest
+import grails.buildtestdata.BuildDataUnitTest
 
-trait DomainTestBase extends BuildDataTest {
+trait DomainTestBase extends BuildDataUnitTest {
 
     Class createDomainClass(String classText) {
         Class domainClass = new GroovyClassLoader().parseClass(classText)


### PR DESCRIPTION
I have run into people being confused on numerous occasions using BuildDataTest in integrationTests causing flaky tests. Therefore I think the naming should be more explicit to prevent the confusion.